### PR TITLE
nft: Add support for named counters and handlers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ support in the kernel and the `nft` executable.
 
 To run the unit-tests, use this command from the project root:
 ```bash
-./autmation/run-tests.sh --unit-test
+./automation/run-tests.sh --unit-test
 ```
 
 To run the integration-tests, use this command from the project root:
 ```bash
-./autmation/run-tests.sh --integration-test
+./automation/run-tests.sh --integration-test
 ```
 
 ## Help utilities

--- a/nft/config/config_test.go
+++ b/nft/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	nftconfig "github.com/networkplumbing/go-nft/nft/config"
 	"github.com/networkplumbing/go-nft/nft/schema"

--- a/nft/config/counter.go
+++ b/nft/config/counter.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package config
+
+import (
+	"github.com/networkplumbing/go-nft/nft/schema"
+)
+
+// AddCounter appends the given named counter to the nftable config.
+// The rule is added without an explicit action (`add`).
+// Adding multiple times the same named counter has no affect when the config is applied.
+func (c *Config) AddCounter(counter *schema.NamedCounter) {
+	nftable := schema.Nftable{Counter: counter}
+	c.Nftables = append(c.Nftables, nftable)
+}
+
+// DeleteCounter appends a given rule to the nftable config with the `delete` action.
+// Attempting to delete a non-existing named counter, results with a failure when the config is applied.
+func (c *Config) DeleteCounter(counter *schema.NamedCounter) {
+	nftable := schema.Nftable{Delete: &schema.Objects{Counter: counter}}
+	c.Nftables = append(c.Nftables, nftable)
+}
+
+// LookupCounter searches the configuration for a matching counter and returns it.
+// The counter is matched first by the table.
+// Mutating the returned counter will result in mutating the configuration.
+func (c *Config) LookupCounter(toFind *schema.NamedCounter) *schema.NamedCounter {
+	for _, nftable := range c.Nftables {
+		if counter := nftable.Counter; counter != nil {
+			match := counter.Table == toFind.Table && counter.Family == toFind.Family && counter.Name == toFind.Name
+			if match {
+				return counter
+			}
+		}
+	}
+	return nil
+}

--- a/nft/config/counter_test.go
+++ b/nft/config/counter_test.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package config_test
+
+import (
+	"fmt"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/networkplumbing/go-nft/nft"
+	"github.com/networkplumbing/go-nft/nft/schema"
+)
+
+type CounterAction string
+
+// Counter Actions
+const (
+	CounterADD    CounterAction = "add"
+	CounterDELETE CounterAction = "delete"
+)
+
+type counterActionFunc func(*nft.Config, *schema.NamedCounter)
+
+const counterName = "test-counter"
+
+func TestCounter(t *testing.T) {
+	testCounterActions(t)
+	testCounterLookup(t)
+}
+
+func testCounterActions(t *testing.T) {
+	actions := map[CounterAction]counterActionFunc{
+		CounterADD:    func(c *nft.Config, t *schema.NamedCounter) { c.AddCounter(t) },
+		CounterDELETE: func(c *nft.Config, t *schema.NamedCounter) { c.DeleteCounter(t) },
+	}
+	table := nft.NewTable(tableName, nft.FamilyIP)
+	counter := nft.NewCounter(table, counterName)
+
+	for action, actionFunc := range actions {
+		testName := fmt.Sprintf("%s counter", string(action))
+
+		t.Run(testName, func(t *testing.T) {
+			config := nft.NewConfig()
+			actionFunc(config, counter)
+
+			serializedConfig, err := config.ToJSON()
+			assert.NoError(t, err)
+
+			counterArgs := fmt.Sprintf(`"family":%q,"table":%q,"name":%q`, table.Family, table.Name, counterName)
+			var expected []byte
+			if action == CounterADD {
+				expected = []byte(fmt.Sprintf(`{"nftables":[{"counter":{%s}}]}`, counterArgs))
+			} else {
+				expected = []byte(fmt.Sprintf(`{"nftables":[{%q:{"counter":{%s}}}]}`, action, counterArgs))
+			}
+
+			assert.Equal(t, string(expected), string(serializedConfig))
+		})
+	}
+}
+
+func testCounterLookup(t *testing.T) {
+	config := nft.NewConfig()
+	table_inet := nft.NewTable("table-inet", nft.FamilyINET)
+	config.AddTable(table_inet)
+
+	counter := nft.NewCounter(table_inet, "test-counter")
+	config.AddCounter(counter)
+
+	t.Run("Lookup an existing named counter", func(t *testing.T) {
+		c := config.LookupCounter(counter)
+		assert.Equal(t, counter, c)
+	})
+
+	t.Run("Lookup a missing named counter", func(t *testing.T) {
+		c := nft.NewCounter(table_inet, "counter-na")
+		assert.Nil(t, config.LookupCounter(c))
+	})
+}

--- a/nft/counter.go
+++ b/nft/counter.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package nft
+
+import (
+	"github.com/networkplumbing/go-nft/nft/schema"
+)
+
+// NewCounter returns a new schema counter structure for a named counter.
+func NewCounter(table *schema.Table, name string) *schema.NamedCounter {
+	c := &schema.NamedCounter{
+		Family: table.Family,
+		Table:  table.Name,
+		Name:   name,
+	}
+
+	return c
+}

--- a/nft/schema/chain.go
+++ b/nft/schema/chain.go
@@ -46,6 +46,7 @@ type Chain struct {
 	Family string `json:"family"`
 	Table  string `json:"table"`
 	Name   string `json:"name"`
+	Handle *int   `json:"handle,omitempty"`
 	Type   string `json:"type,omitempty"`
 	Hook   string `json:"hook,omitempty"`
 	Prio   *int   `json:"prio,omitempty"`

--- a/nft/schema/counter.go
+++ b/nft/schema/counter.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package schema
+
+type NamedCounter struct {
+	Family  string `json:"family"`
+	Table   string `json:"table"`
+	Name    string `json:"name"`
+	Handle  *int   `json:"handle,omitempty"`
+	Packets *int   `json:"packets,omitempty"`
+	Bytes   *int   `json:"bytes,omitempty"`
+}

--- a/nft/schema/schema.go
+++ b/nft/schema/schema.go
@@ -30,10 +30,11 @@ type Root struct {
 const ruleSetKey = "ruleset"
 
 type Objects struct {
-	Table   *Table `json:"table,omitempty"`
-	Chain   *Chain `json:"chain,omitempty"`
-	Rule    *Rule  `json:"rule,omitempty"`
-	Ruleset bool   `json:"-"`
+	Table   *Table        `json:"table,omitempty"`
+	Chain   *Chain        `json:"chain,omitempty"`
+	Rule    *Rule         `json:"rule,omitempty"`
+	Counter *NamedCounter `json:"counter,omitempty"`
+	Ruleset bool          `json:"-"`
 }
 
 func (o Objects) MarshalJSON() ([]byte, error) {
@@ -62,9 +63,10 @@ func (o Objects) MarshalJSON() ([]byte, error) {
 }
 
 type Nftable struct {
-	Table *Table `json:"table,omitempty"`
-	Chain *Chain `json:"chain,omitempty"`
-	Rule  *Rule  `json:"rule,omitempty"`
+	Table   *Table        `json:"table,omitempty"`
+	Chain   *Chain        `json:"chain,omitempty"`
+	Rule    *Rule         `json:"rule,omitempty"`
+	Counter *NamedCounter `json:"counter,omitempty"`
 
 	Add    *Objects `json:"add,omitempty"`
 	Delete *Objects `json:"delete,omitempty"`

--- a/nft/schema/table.go
+++ b/nft/schema/table.go
@@ -32,4 +32,5 @@ const (
 type Table struct {
 	Family string `json:"family"`
 	Name   string `json:"name"`
+	Handle *int   `json:"handle,omitempty"`
 }

--- a/tests/example/nat_test.go
+++ b/tests/example/nat_test.go
@@ -56,7 +56,7 @@ func buildMasqueradeConfig() *nft.Config {
 
 	chainPriority := 100
 
-	return &nft.Config{schema.Root{Nftables: []schema.Nftable{
+	return &nft.Config{Root: schema.Root{Nftables: []schema.Nftable{
 		{Table: &schema.Table{Family: schema.FamilyIP, Name: ip4TableName}},
 		{Table: &schema.Table{Family: schema.FamilyIP6, Name: ip6TableName}},
 

--- a/tests/nftlib/nftlib_test.go
+++ b/tests/nftlib/nftlib_test.go
@@ -42,12 +42,14 @@ func TestNftlib(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Len(t, newConfig.Nftables, 2, "Expecting the metainfo and an empty table entry")
-		assert.Equal(t, config.Nftables[0], newConfig.Nftables[1])
+		newConfig = testlib.NormalizeConfigForComparison(newConfig)
+		assert.Equal(t, config.Nftables[0], newConfig.Nftables[0])
 		_, err = nftlib.ReadConfig()
 		assert.NoError(t, err)
 
 		newConfig, err = nftlib.ApplyConfigEcho(config)
 		assert.NoError(t, err)
+		newConfig = testlib.NormalizeConfigForComparison(newConfig)
 		assert.Len(t, newConfig.Nftables, 1, "Expecting just the empty table entry")
 		assert.Equal(t, config.Nftables, newConfig.Nftables)
 	})


### PR DESCRIPTION
Add support for named counters in nftables. In addition, expose the handlers when reading the configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/go-nft/1)
<!-- Reviewable:end -->
